### PR TITLE
Zmena formatovani castky

### DIFF
--- a/src/vplacek/QRPlatba/QRPlatba.php
+++ b/src/vplacek/QRPlatba/QRPlatba.php
@@ -97,7 +97,7 @@ class QRPlatba {
 	 * @return $this
 	 */
 	public function setAmount(float $amount): QRPlatba {
-		$this->keys['AM'] = sprintf('%.2f', $amount);
+		$this->keys['AM'] = number_format($amount, 2, '.', '');
 
 		return $this;
 	}


### PR DESCRIPTION
sprintf respektuje locale, coz v nekterych pripadech znamena desetinnou
carku misto tecky, ackoliv specifikace jasne rika, ze to ma byt tecka.

number_format locale ignoruje a funguje universalne

Signed-off-by: Jakub Koudelka <koudelka.j@gmail.com>