### PR TITLE
Opraveno bug pri zadavani konstantniho symbolu

### DIFF
--- a/src/vplacek/QRPlatba/QRPlatba.php
+++ b/src/vplacek/QRPlatba/QRPlatba.php
@@ -164,7 +164,7 @@ class QRPlatba {
 			throw new \InvalidArgumentException('Constant symbol is higher than 10 chars');
 		}
 
-		$this->keys['X-CS'] = $cs;
+		$this->keys['X-KS'] = $cs;
 
 		return $this;
 	}


### PR DESCRIPTION
namisto X-KS se vklada X-CS

Signed-off-by: Jakub Koudelka <koudelka.j@gmail.com>